### PR TITLE
Cadastro Unidade #3 - modificaçoes pedidas na Code review.

### DIFF
--- a/src/components/cadastroUnidade/Cadastro.jsx
+++ b/src/components/cadastroUnidade/Cadastro.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import axios from "axios";
 import { Form } from "../form/Form";
 import "./Cadastro.css";
+import PropTypes from "prop-types";
 
 export const CadastroUnidade = ({ mudarFormulario }) => {
   const [error, setError] = useState(false);
@@ -77,4 +78,8 @@ export const CadastroUnidade = ({ mudarFormulario }) => {
       />
     </div>
   );
+};
+
+CadastroUnidade.propTypes = {
+  mudarFormulario: PropTypes.func.isRequired,
 };

--- a/src/components/cadastroUnidade/Cadastro.jsx
+++ b/src/components/cadastroUnidade/Cadastro.jsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import { Form } from "../form/Form";
 import "./Cadastro.css";
 
-export const CadastroUnidade = () => {
+export const CadastroUnidade = ({ mudarFormulario }) => {
   const [error, setError] = useState(false);
 
   const unidadeFields = [
@@ -51,6 +51,7 @@ export const CadastroUnidade = () => {
       if (updatedResponse.status === 201) {
         alert("Unidade cadastrada com sucesso");
         setError(false);
+        mudarFormulario();
       } else {
         alert("Erro ao cadastrar unidade");
         setError(true);

--- a/src/components/cadastroUnidade/Cadastro.jsx
+++ b/src/components/cadastroUnidade/Cadastro.jsx
@@ -49,14 +49,14 @@ export const CadastroUnidade = () => {
     try {
       const updatedResponse = await axios.post(ENDPOINT_UNIDADES, novaUnidade);
       if (updatedResponse.status === 201) {
-        console.log("Unidade cadastrada com sucesso");
+        alert("Unidade cadastrada com sucesso");
         setError(false);
       } else {
-        console.log("Erro ao cadastrar unidade");
+        alert("Erro ao cadastrar unidade");
         setError(true);
       }
     } catch (error) {
-      console.error(`Error: ${error.msg}`);
+      alert(`Error: ${error}`);
       setError(true);
     }
   };

--- a/src/pages/unidade-geradora/UnidadeGeradora.jsx
+++ b/src/pages/unidade-geradora/UnidadeGeradora.jsx
@@ -4,12 +4,15 @@ import { useState } from "react";
 export const UnidadeGeradora = () => {
   const [renderizarCadastroUnidade, setRenderizarCadastroUnidade] =
     useState(false);
+  const mudarFormulario = () => {
+    setRenderizarCadastroUnidade(!renderizarCadastroUnidade);
+  };
 
   return (
     <>
       {/* este button e apenas para testes e debera ser eliminado quando este pronto o menu lateral */}
       <button
-        onClick={() => setRenderizarCadastroUnidade(!renderizarCadastroUnidade)}
+        onClick={() => mudarFormulario()}
       >
         Mudar formulario{" "}
       </button>

--- a/src/pages/unidade-geradora/UnidadeGeradora.jsx
+++ b/src/pages/unidade-geradora/UnidadeGeradora.jsx
@@ -17,7 +17,7 @@ export const UnidadeGeradora = () => {
         Mudar formulario{" "}
       </button>
       {renderizarCadastroUnidade ? (
-        <CadastroUnidade />
+        <CadastroUnidade mudarFormulario={mudarFormulario}/>
       ) : (
         <>
           <h1>Lista de unidades</h1>


### PR DESCRIPTION
# O que foi feito?
- Migração de erros que estavam no console para alerts().
- Criação de função para mudar de formulário.
- Quando o cadastro da nova unidade é bem-sucedido, retorna a mostrar o formulário de lista de unidades.

# Como testar?
## Startamos o Json Server e tambem o APP com os siguientes comandos no seu terminal : 
```bash
npm run server
```
```bash
npm run dev
```
## Saidas esperadas do terminal
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/7373cccb-1c64-42ad-a553-d66a543153a2)
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/d8142a1f-ce91-4dbd-9256-5fe2f7a04610)
## Abra o seu navegador web de preferência e dirija-se ao endereço http://localhost:5173/unidade-geradora. Deverá observar a seguinte tela:
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/d02713d9-184a-4ffd-8571-6eeb1eef1575)
# Resultado esperado:
## Ao clicar no botão 'Mudar de Formulário', deve renderizar a seguinte tela:
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/fe73dca5-f667-4b58-befc-496121d1b03c)
## Caso a API estei indisponivel 
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/a8c80add-6a98-4eeb-97f5-4b8e3cadbc95)
## Caso o cadastro seija bem-succedido 
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/6ad88eb6-9eee-42e4-87fa-a6b10ab7f476)

Si aceitar o alert deve voltar para o formulario de Lista Unidades como na sieguiente foto
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/8b405488-f9a0-4c6e-848b-c8750113b038)

