### PR TITLE
Tela de dashboard #8

### DIFF
--- a/database/data.json
+++ b/database/data.json
@@ -27,14 +27,6 @@
       "marca": "Borboletinha",
       "modelo": "220w",
       "ativa": false
-    },
-    {
-      "id": "arr",
-      "apelido": "Painel 3",
-      "local": "Rua 15",
-      "marca": "SolarEdge",
-      "modelo": "550w",
-      "ativa": true
     }
   ],
   "lancamentos": [
@@ -49,12 +41,6 @@
       "id_unidade": "def",
       "data": "03/2022",
       "total": 160
-    },
-    {
-      "id": "124",
-      "id_unidade": "def",
-      "data": "03/2022",
-      "total": 95
     }
   ]
 }

--- a/database/data.json
+++ b/database/data.json
@@ -27,6 +27,14 @@
       "marca": "Borboletinha",
       "modelo": "220w",
       "ativa": false
+    },
+    {
+      "id": "arr",
+      "apelido": "Painel 3",
+      "local": "Rua 15",
+      "marca": "SolarEdge",
+      "modelo": "550w",
+      "ativa": true
     }
   ],
   "lancamentos": [
@@ -41,6 +49,12 @@
       "id_unidade": "def",
       "data": "03/2022",
       "total": 160
+    },
+    {
+      "id": "124",
+      "id_unidade": "def",
+      "data": "03/2022",
+      "total": 95
     }
   ]
 }

--- a/src/components/cardUnidades/cardUnidades.jsx
+++ b/src/components/cardUnidades/cardUnidades.jsx
@@ -7,7 +7,7 @@ const CardUnidades = ({titulo,valor}) => {
                 <p>{titulo}</p>
             </div>
             <div className={styles.textUnidade}>
-                <p>{valor}</p>
+                <p>{titulo=="Média de energia" ? valor.toString()+" Kw" : valor}</p>
             </div>
         </div>
     )

--- a/src/components/cardUnidades/cardUnidades.jsx
+++ b/src/components/cardUnidades/cardUnidades.jsx
@@ -1,4 +1,4 @@
-import styles from './CardUnidades.module.css'
+import styles from './cardUnidades.module.css'
 
 const CardUnidades = ({titulo,valor}) => {
     return (

--- a/src/components/cardUnidades/cardUnidades.jsx
+++ b/src/components/cardUnidades/cardUnidades.jsx
@@ -7,7 +7,7 @@ const CardUnidades = ({titulo,valor}) => {
                 <p>{titulo}</p>
             </div>
             <div className={styles.textUnidade}>
-                <p>{titulo=="Média de energia" ? valor.toString()+" Kw" : valor}</p>
+                <p>{titulo=="Média de energia" ? valor.toString()+" kW" : valor}</p>
             </div>
         </div>
     )

--- a/src/components/cardUnidades/cardUnidades.jsx
+++ b/src/components/cardUnidades/cardUnidades.jsx
@@ -1,0 +1,16 @@
+import styles from './CardUnidades.module.css'
+
+const CardUnidades = ({titulo,valor}) => {
+    return (
+        <div className={styles.boxCard}>
+            <div className={styles.textTipo}>
+                <p>{titulo}</p>
+            </div>
+            <div className={styles.textUnidade}>
+                <p>{valor}</p>
+            </div>
+        </div>
+    )
+}
+
+export default CardUnidades

--- a/src/components/cardUnidades/cardUnidades.module.css
+++ b/src/components/cardUnidades/cardUnidades.module.css
@@ -1,0 +1,33 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Mulish:wght@700&family=Poppins:wght@500&family=Roboto:wght@500&display=swap');
+
+
+.boxCard{
+    width: 258px;
+    height: 134px;
+    background-color: #fff;
+    border-radius: 8px;
+    border: solid 1px #DFE0EB;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 10px;
+}
+
+.textTipo{
+    color:#9FA2B4;
+    font-size: 19px;
+    font-weight: 500;
+    font-family: 'Mulish', sans-serif;
+    line-height: 24px;
+    letter-spacing: 1px;
+}
+.textUnidade{
+    color:#252733;
+    font-size: 40px;
+    font-weight: 700;
+    margin-top: 24px;
+    font-family: 'Mulish', sans-serif;
+    line-height: 50px;
+    letter-spacing: 1px;
+}

--- a/src/components/dashboardCards/dashboardCards.jsx
+++ b/src/components/dashboardCards/dashboardCards.jsx
@@ -1,5 +1,5 @@
 import CardUnidades from "../cardUnidades/cardUnidades"
-import styles from './DashboardCards.module.css'
+import styles from './dashboardCards.module.css'
 import dadosUnidades from "../../services/dadosUnidades"
 import dadosLacamentos from "../../services/dadosLancamentos";
 

--- a/src/components/dashboardCards/dashboardCards.jsx
+++ b/src/components/dashboardCards/dashboardCards.jsx
@@ -1,0 +1,18 @@
+import CardUnidades from "../cardUnidades/cardUnidades"
+import styles from './DashboardCards.module.css'
+import dadosUnidades from "../../services/dadosUnidades"
+import dadosLacamentos from "../../services/dadosLancamentos";
+
+const DashboardCards = () => {
+    const { unidades,unidadesAtivas,unidadeInativa } = dadosUnidades();
+    const {mediaConsumo}=dadosLacamentos();
+    return (
+        <div className={styles.cardsUnidadades}>
+            <CardUnidades titulo={"Total unidades"} valor={unidades.length}/>
+            <CardUnidades titulo={"Unidades Ativas"} valor={unidadeInativa.length}/>
+            <CardUnidades titulo={"Unidades Inativas"} valor={unidadesAtivas.length}/>
+            <CardUnidades titulo={"Média de energia"} valor={mediaConsumo}/>
+        </div>
+    )
+}
+export default DashboardCards

--- a/src/components/dashboardCards/dashboardCards.module.css
+++ b/src/components/dashboardCards/dashboardCards.module.css
@@ -1,0 +1,8 @@
+.cardsUnidadades{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top:80px;
+    width: 100%;
+    gap: 24px;
+}

--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -1,9 +1,9 @@
-import { MenuLateral } from '../../components/menu-lateral/menu-lateral'
+import DashboardCards from "../../components/dashboardCards/dashboardCards"
 
 export const Dashboard = () => {
   return (
     <div>
-      <div>Dashboard</div>
+      <DashboardCards />
     </div>
   )
 }

--- a/src/services/dadosLancamentos.jsx
+++ b/src/services/dadosLancamentos.jsx
@@ -14,7 +14,7 @@ export default function dadosLacamentos() {
         setCarregando(false);
         setMediaConsumo(parseFloat((response.data.map(
           lancamentos => lancamentos.total).reduce((a, b) => a + b, 0) / response.data.length))
-          .toFixed(2));
+          .toFixed(0));
       } catch (error) {
         console.log(error);
       }

--- a/src/services/dadosLancamentos.jsx
+++ b/src/services/dadosLancamentos.jsx
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+export default function dadosLacamentos() {
+ const[mediaConsumo, setMediaConsumo] = useState([]);
+  const [carregando, setCarregando] = useState(true);
+
+  const urlLancamento = "http://localhost:3000/lancamentos";
+
+  useEffect(() => {
+    async function fetchLancamentos() {
+      try {
+        const response = await axios.get(urlLancamento);
+        setCarregando(false);
+        setMediaConsumo(parseFloat((response.data.map(
+          lancamentos => lancamentos.total).reduce((a, b) => a + b, 0) / response.data.length))
+          .toFixed(2));
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    fetchLancamentos();
+  }, []);
+  return {mediaConsumo};
+}

--- a/src/services/dadosUnidades.jsx
+++ b/src/services/dadosUnidades.jsx
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+export default function dadosUnidades() {
+  const [unidades, setUnidades] = useState([]);
+  const [unidadesAtivas, setUnidadesAtivas] = useState([]); 
+  const [unidadeInativa , setUnidadeInativa] = useState([]);
+  const [carregando, setCarregando] = useState(true);
+
+  const urlUnidades = "http://localhost:3000/unidades";
+
+  useEffect(() => {
+    async function fetchUnidades() {
+      try {
+        const response = await axios.get(urlUnidades);
+        setUnidades(response.data);
+        setCarregando(false);
+        setUnidadesAtivas(response.data.filter(unidade => unidade.ativa === false));
+        setUnidadeInativa(response.data.filter(unidade => unidade.ativa === true));
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    fetchUnidades();
+  }, []);
+
+  return { unidades,unidadesAtivas,unidadeInativa};
+}


### PR DESCRIPTION
## O que foi feito?
Foram implementados os cards que compõem a pagina do dashboard. Cada um dos cards totalizam respectivamente o total de unidades, unidades ativas, unidades inativas e calcula a média de geração. Os cards foram criados conforme layout no [figma](https://www.figma.com/file/4oDPtiefH9ZCQ17RU9JZQz/Projeto-DevInHouse?node-id=0%3A1&mode=dev). Como o card não apresenta casa decimal no valor da média, o cálculo prevê um arredondamento de forma a não apresentar os valores decimais. A unidade **kw** foi considerado fora do padrão da nomeclatura de unidade de potência, sendo assim foi utilizado a nomeclatura **kW**

![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/63860659/e10b4043-8d22-4e7a-8495-84ed93a6c030)

## Como testar?
Primeiramente deve rodar os servidores com os seguintes comandos no terminal:
**"npm run dev"** para o servidor web
**"npm run server"** para o servidor json

Adicione novos valores de **lançamento, unidades ativas e inativas** no arquivo data.json para observar o comportamento dos cards.
Exemplo de formato dos dados a serem inseridos:
**para lançamento:**
    {
      "id": "165",
      "id_unidade": "def",
      "data": "04/2022",
      "total": 95
    }

**para unidade:**
    {
      "id": "ula",
      "apelido": "Painel Central",
      "local": "Avenida Geral",
      "marca": "Intelbras",
      "modelo": "250w",
      "ativa": true
    }

## Resultado previsto:
A imagem prevista inicialmente antes da inseção dos dados será esta a seguir:
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/63860659/de90af8f-2ae4-4fa4-bee5-76d8674d5864)

A imagem esperada após a inserção dos dados exemplo será a seguinte:
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/63860659/ff455424-8254-4115-b73c-202032d114e2)



