### PR TITLE
🔄️ fix : Bug ao salvar novas unidades a propiedade "ativa" salvava como "on" e não true | false

### DIFF
--- a/src/components/form/Form.jsx
+++ b/src/components/form/Form.jsx
@@ -7,7 +7,15 @@ export const Form = ({ fields, onSubmit, className, submitButtonLabel }) => {
     const formData = {}; // foi criado um objeto para armazenar os dados do formulário
 
     fields.forEach((field) => {
-      formData[field.name] = event.target[field.name].value; // Preenche o objeto com os valores digitados do formulário
+      if (field.type === "checkbox") {
+        if (event.target[field.name].checked)
+          formData[field.name] = event.target[field.name].checked;
+        else {
+          formData[field.name] = false;
+        }
+      } else {
+        formData[field.name] = event.target[field.name].value; // Preenche o objeto com os valores digitados do formulário
+      }
     });
 
     onSubmit(formData); // para chamar a função onSubmit com o objeto de dados do formulário


### PR DESCRIPTION
# O que foi feito?
- Modifiquei a função handleSubmit() no componente Form. Caso o Field seja um checkbox, valide a propriedade .checked. Se ele for um valor truthy, atribua o valor true; caso contrário, atribua o valor false ao objeto.

# Como testar ?
## Startamos o Json Server e tambem o APP com os siguientes comandos no seu terminal : 
```bash
npm run server
```
```bash
npm run dev
```

-No seu navegador, visite o endereço http://localhost:5173/unidade-geradora e clique no botão 'Mudar Formulário'.

![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/0634010d-c003-4f1f-9168-3e9713783c74)
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/25da04f6-0a6d-4ce5-9404-64d45a79a031)
- Preencha e envie a solicitação duas vezes; marque o checkbox como 'ativa' em uma delas e, na outra, não marque como 'ativa', conforme as seguintes imagens.
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/74c8764b-d85a-4821-a290-79113a3bd51d)
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/ac60104b-0b7b-45f6-888a-7afb0ba7d1f4)

# Saida esperada :
No seu navegador, visite o endereço http://localhost:3000/unidades e verifique se o JSON agora inclui as duas novas unidades, uma com o valor true e outra com o valor false na propriedade 'ativa'.
![image](https://github.com/FullStack-Itaguacu/react-solarenergy/assets/124309725/0b2b4725-dece-4e4e-8d1b-03dd6194ddbd)
