### PR TITLE
fix: forçar o format numérico chave total do json

### DIFF
--- a/database/data.json
+++ b/database/data.json
@@ -45,8 +45,26 @@
     {
       "id_unidade": "abc",
       "data": "2023-09",
-      "total": "56",
+      "total": 56,
       "id": "fT7wmgy"
+    },
+    {
+      "id_unidade": "abc",
+      "data": "2023-10",
+      "total": 100,
+      "id": "0HIdjnk"
+    },
+    {
+      "id_unidade": "abc",
+      "data": "2023-12",
+      "total": 150,
+      "id": "LBOiBdF"
+    },
+    {
+      "id_unidade": "abc",
+      "data": "2023-06",
+      "total": 250,
+      "id": "gtKX26d"
     }
   ]
 }

--- a/src/components/Lancamento-mensal/LancamentoMensal.jsx
+++ b/src/components/Lancamento-mensal/LancamentoMensal.jsx
@@ -97,7 +97,7 @@ export const LancamentoGeracaoMensal = () => {
                 type="number"
                 name="kw"
                 value={total}
-                onChange={(e) => setTotal(e.target.value)}
+                onChange={(e) => setTotal(e.target.valueAsNumber)}
               />
             </div>
             <div className={styles.botao}>


### PR DESCRIPTION
## O que foi feito?
Alterada uma linha de código para que fosse lido um valor no input e gravado no json como valor numérico para chave total, e não como string.
    {
      "id_unidade": "abc",
      "data": "2023-12",
      **"total": "150",**
      "id": "LBOiBdF"
    }

## Como testar?
Para rodar a aplicação são necessários os seguintes comandos no terminal:
`npm run dev`
`npm run server`

em seguida vá até a opção **Cadastro de energia geradora** e insira mais um registro de geração.

## O que esperar?
Devemos esperar que a chave total receba um valor numérico no arquivo json data.json como abaixo.
    {
      "id_unidade": "abc",
      "data": "2023-12",
      **"total": 150,**
      "id": "LBOiBdF"
    }